### PR TITLE
CMP-1944: Default status not reflected in GA

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,8 +2,10 @@ homepage: "https://www.didomi.io/"
 documentation: "https://developers.didomi.io/"
 versions:
   # Latest version
+  - sha: 24aebb9236630a3ca2535f613e7ce88b45303788
+    changeNotes: Add support to additional consent types (functionality_storage, personalization_storage, security_storage)
+  # Older versions
   - sha: 3df6cb2abf72dac146d9b1b623fedb7bd929bffa
     changeNotes: Point to sdk.privacy-center.org when embedding Didomi SDK.
-  # Older versions
   - sha: 787de6ba596b21e529bcbdea25ca0a36e8afb870
     changeNotes: Initial release.


### PR DESCRIPTION
When the states for `ad_storage` and `analytics_storage` come from something like `didomiVendorsConsentUnknown: "didomi:google,c:jsdelivr,c:googleana-4TXnJigR,"`, a.k.a, the user has not made a choice, the current code was defaulting to `false` everytime.

If for some reason a client would setup `ad_storage` and `analytics_storage` to `true`, the template would not work as expected.

This PR,

- Fixes the issue mentioned above
- Includes the `wait_for_update` parameter to the`setDefaultConsentState` call, as recommended by google (set to 500 ms)
- Add unit tests for the cases being fixed

--- Additional notes ---

When running the tests individually, they all go to green. However, when ran together, a couple of themare failing
<img width="712" alt="Screen Shot 2021-11-02 at 12 10 53 PM" src="https://user-images.githubusercontent.com/30706016/139859058-abefe8c0-e71b-44e2-a297-940ebdec4f1c.png">

Failing one going to green when ran individually
<img width="714" alt="Screen Shot 2021-11-02 at 12 10 44 PM" src="https://user-images.githubusercontent.com/30706016/139859092-f22226bd-8794-42ef-953b-7a6b63b8b4a6.png">

It seems to be something related to the Sandboxed Javascript testing environment. See the comment by "Mark B" at the bottom of this [post](https://www.simoahava.com/analytics/writing-tests-for-custom-templates-google-tag-manager/) for reference.


