### PR TITLE
CMP-2956: Remove default value for table component

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -148,8 +148,7 @@ ___TEMPLATE_PARAMETERS___
             },
             "isUnique": false
           }
-        ],
-        "defaultValue": ""
+        ]
       }
     ],
     "help": "These fields are denied by default for all regions unless overwritten with a blank region field"


### PR DESCRIPTION
A default value assigned to a table UI component is causing issues for the template. This PR removes the value
Current issue:
<img width="668" alt="Screenshot 2022-09-28 at 17 58 10" src="https://user-images.githubusercontent.com/30706016/192836022-b82f68b7-45d8-413e-a877-675982cdcd5d.png">
See https://didomi.atlassian.net/browse/CMP-2956

After this fix
<img width="983" alt="Screenshot 2022-09-28 at 18 24 58" src="https://user-images.githubusercontent.com/30706016/192835947-bbf80f3a-1528-47da-b6d0-eea664f9c6cc.png">
