### PR TITLE
CMP-4445: Include setDeniedConsentValuesForAllRegions / Unify gtagset calls

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -462,7 +462,7 @@ const setupListeners = () => {
 };
 
 const setDeniedConsentValuesForAllRegions = () => {
-  // Set default consent state values for all regions
+  // Set default consent state values to denied for all regions
   setDefaultConsentState({
     'ad_storage': 'denied',
     'analytics_storage': 'denied',


### PR DESCRIPTION
Ticket [CMP-4445](https://didomi.atlassian.net/browse/CMP-4445)

- Implement `setDeniedConsentValuesForAllRegions` and the `dataContainsAllRegionsRecord` value to include these scenarios: https://didomi.atlassian.net/browse/CMP-4445?focusedCommentId=22724
- Update tests
