### PR TITLE
feat: add regional consent defaults and gcm vendor updates

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -325,22 +325,6 @@ const copyFromWindow = require('copyFromWindow');
 const createQueue = require('createQueue');
 const Object = require('Object');
 
-const regionsGrantedByDefault = [
-  'US-CA',
-  'US-CO',
-  'US-CT',
-  'US-DE',
-  'US-FL',
-  'US-IA',
-  'US-MT',
-  'US-NH',
-  'US-NJ',
-  'US-OR',
-  'US-TX',
-  'US-UT',
-  'US-VA',
-];
-
 const regionsDeniedByDefault = [
   'AD',
   'AT',
@@ -556,24 +540,9 @@ const setupListeners = () => {
   });
 };
 
-const setDeniedConsentValuesForAllRegions = () => {
+const setGrantedConsentValuesForAllRegions = () => {
   // Set default consent state values to denied for all regions
   setDefaultConsentState({
-    'ad_storage': 'denied',
-    'analytics_storage': 'denied',
-    'functionality_storage': 'denied',
-    'personalization_storage': 'denied',
-    'security_storage': 'granted',
-    'ad_user_data': 'denied',
-    'ad_personalization': 'denied',
-    'wait_for_update': 500,
-  });
-};
-
-const setDefaultSettings = data => {
-  // Set default consent state values for regions granted by default
-  setDefaultConsentState({
-    'region': regionsGrantedByDefault,
     'ad_storage': 'granted',
     'analytics_storage': 'granted',
     'functionality_storage': 'granted',
@@ -583,6 +552,9 @@ const setDefaultSettings = data => {
     'ad_personalization': 'granted',
     'wait_for_update': 500,
   });
+};
+
+const setDefaultSettings = data => {
   // Set default consent state values for regions denied by default
   setDefaultConsentState({
     'region': regionsDeniedByDefault,
@@ -590,7 +562,7 @@ const setDefaultSettings = data => {
     'analytics_storage': 'denied',
     'functionality_storage': 'denied',
     'personalization_storage': 'denied',
-    'security_storage': 'denied',
+    'security_storage': 'granted',
     'ad_user_data': 'denied',
     'ad_personalization': 'denied',
     'wait_for_update': 500,
@@ -624,10 +596,10 @@ const setDefaultSettings = data => {
     });
     
     if (!dataContainsAllRegionsRecord) {
-      setDeniedConsentValuesForAllRegions();
+      setGrantedConsentValuesForAllRegions();
     }
   } else {
-    setDeniedConsentValuesForAllRegions();
+    setGrantedConsentValuesForAllRegions();
   }
   // Set default additional settings values
   gtagSet({
@@ -1543,6 +1515,18 @@ scenarios:
     runCode(mockData);
 
     assertApi('setDefaultConsentState').wasCalledWith({
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'security_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
+      'wait_for_update': 500
+    });
+
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsDeniedByDefault,
       'ad_storage': 'denied',
       'analytics_storage': 'denied',
       'functionality_storage': 'denied',
@@ -1552,6 +1536,7 @@ scenarios:
       'ad_personalization': 'denied',
       'wait_for_update': 500
     });
+
 
 
     /*
@@ -1663,6 +1648,18 @@ scenarios:
     didomiOnReady[0]();
 
     assertApi('setDefaultConsentState').wasCalledWith({
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'security_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
+      'wait_for_update': 500
+    });
+
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsDeniedByDefault,
       'ad_storage': 'denied',
       'analytics_storage': 'denied',
       'functionality_storage': 'denied',
@@ -1740,6 +1737,18 @@ scenarios:
     runCode(mockData);
 
     assertApi('setDefaultConsentState').wasCalledWith({
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'security_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
+      'wait_for_update': 500
+    });
+
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsDeniedByDefault,
       'ad_storage': 'denied',
       'analytics_storage': 'denied',
       'functionality_storage': 'denied',
@@ -1816,15 +1825,19 @@ scenarios:
     \ = \"google,googleana-4TXnJigR,\";\ndidomiState.didomiVendorsUnknown = \"\";\n\
     setInWindow('didomiState', didomiState, true);\n\n// Simulate on-ready event trigger\n\
     didomiOnReady[0]();\n\nassertApi('setDefaultConsentState').wasCalledWith({\n \
-    \ 'ad_storage': 'denied',\n  'analytics_storage': 'denied',\n  'functionality_storage':\
-    \ 'denied',\n  'personalization_storage': 'denied',\n  'security_storage': 'granted',\n\
-    \  'ad_user_data': 'denied',\n  'ad_personalization': 'denied',\n  'wait_for_update':\
-    \ 500\n});\n/*\nFrom a google's email:\nBecause of the way Tag Manager times the\
-    \ application of consent updates (aligned with event boundaries), the method isConsentGranted\
-    \ will not be an effective way to test for any consent changes that happened during\
-    \ your test. Instead, I would suggest using assertApi().wasCalledWith() to ensure\
-    \ that the setDefaultConsentState and updateConsentState APIs were called with\
-    \ the expected parameters.\n\nassertThat(isConsentGranted('ad_storage')).isEqualTo(true);\n\
+    \ 'ad_storage': 'granted',\n  'analytics_storage': 'granted',\n  'functionality_storage':\
+    \ 'granted',\n  'personalization_storage': 'granted',\n  'security_storage': 'granted',\n\
+    \  'ad_user_data': 'granted',\n  'ad_personalization': 'granted',\n  'wait_for_update':\
+    \ 500\n});\n\nassertApi('setDefaultConsentState').wasCalledWith({\n  'region':\
+    \ regionsDeniedByDefault,\n  'ad_storage': 'denied',\n  'analytics_storage': 'denied',\n\
+    \  'functionality_storage': 'denied',\n  'personalization_storage': 'denied',\n\
+    \  'security_storage': 'granted',\n  'ad_user_data': 'denied',\n  'ad_personalization':\
+    \ 'denied',\n  'wait_for_update': 500\n});\n\n/*\nFrom a google's email:\nBecause\
+    \ of the way Tag Manager times the application of consent updates (aligned with\
+    \ event boundaries), the method isConsentGranted will not be an effective way\
+    \ to test for any consent changes that happened during your test. Instead, I would\
+    \ suggest using assertApi().wasCalledWith() to ensure that the setDefaultConsentState\
+    \ and updateConsentState APIs were called with the expected parameters.\n\nassertThat(isConsentGranted('ad_storage')).isEqualTo(true);\n\
     assertThat(isConsentGranted('analytics_storage')).isEqualTo(true);\nassertThat(isConsentGranted('functionality_storage')).isEqualTo(true);\n\
     assertThat(isConsentGranted('personalization_storage')).isEqualTo(true);\n*/ \n\
     \nassertThat(isConsentGranted('security_storage')).isEqualTo(true);\nassertApi('updateConsentState').wasCalledWith({'ad_storage':\
@@ -1929,9 +1942,7 @@ scenarios:
     // Call runCode to run the template's code.
     runCode(mockData);
 
-    // setDefaultConsentState is called with Didomi's default values per regiont
     assertApi('setDefaultConsentState').wasCalledWith({
-      'region': regionsGrantedByDefault,
       'ad_storage': 'granted',
       'analytics_storage': 'granted',
       'functionality_storage': 'granted',
@@ -1942,17 +1953,6 @@ scenarios:
       'wait_for_update': 500
     });
 
-    assertApi('setDefaultConsentState').wasCalledWith({
-      'region': regionsDeniedByDefault,
-      'ad_storage': 'denied',
-      'analytics_storage': 'denied',
-      'functionality_storage': 'denied',
-      'personalization_storage': 'denied',
-      'security_storage': 'denied',
-      'ad_user_data': 'denied',
-      'ad_personalization': 'denied',
-      'wait_for_update': 500
-    });
 
 
     // Client specific values are used to override default ones
@@ -1968,15 +1968,15 @@ scenarios:
       'wait_for_update': 500
     });
 
-    // Make sure that setDeniedConsentValuesForAllRegions is called
+    // Make sure that setGrantedConsentValuesForAllRegions is called
     assertApi('setDefaultConsentState').wasCalledWith({
-      'ad_storage': 'denied',
-      'analytics_storage': 'denied',
-      'functionality_storage': 'denied',
-      'personalization_storage': 'denied',
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
       'security_storage': 'granted',
-      'ad_user_data': 'denied',
-      'ad_personalization': 'denied',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
       'wait_for_update': 500
     });
 
@@ -1984,8 +1984,8 @@ scenarios:
 
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
-- name: Default consent values are set correctly for multiple regions (all regions
-    row included)
+- name: Default consent values are correctly overridden for multiple regions (all
+    regions row included)
   code: |-
     mockData.byRegionDefaultStatusTable = [{
       "region": "US-CA, US-CO",
@@ -2009,26 +2009,13 @@ scenarios:
     // Call runCode to run the template's code.
     runCode(mockData);
 
-    // setDefaultConsentState is called with Didomi's default values per regiont
-    assertApi('setDefaultConsentState').wasCalledWith({
-      'region': regionsGrantedByDefault,
-      'ad_storage': 'granted',
-      'analytics_storage': 'granted',
-      'functionality_storage': 'granted',
-      'personalization_storage': 'granted',
-      'security_storage': 'granted',
-      'ad_user_data': 'granted',
-      'ad_personalization': 'granted',
-      'wait_for_update': 500
-    });
-
     assertApi('setDefaultConsentState').wasCalledWith({
       'region': regionsDeniedByDefault,
       'ad_storage': 'denied',
       'analytics_storage': 'denied',
       'functionality_storage': 'denied',
       'personalization_storage': 'denied',
-      'security_storage': 'denied',
+      'security_storage': 'granted',
       'ad_user_data': 'denied',
       'ad_personalization': 'denied',
       'wait_for_update': 500
@@ -2116,22 +2103,6 @@ setup: |-
     "didomiVendorsDisabled": "",
     "didomiVendorsUnknown": "google,googleana-4TXnJigR,",
   };
-
-  const regionsGrantedByDefault = [
-    'US-CA',
-    'US-CO',
-    'US-CT',
-    'US-DE',
-    'US-FL',
-    'US-IA',
-    'US-MT',
-    'US-NH',
-    'US-NJ',
-    'US-OR',
-    'US-TX',
-    'US-UT',
-    'US-VA',
-  ];
 
   const regionsDeniedByDefault = [
     'AD',

--- a/template.tpl
+++ b/template.tpl
@@ -193,6 +193,13 @@ ___TEMPLATE_PARAMETERS___
             "isUnique": false
           }
         ]
+      },
+      {
+        "type": "CHECKBOX",
+        "name": "grantGCMByDefaultOutsideEU",
+        "checkboxText": "Set all GCM purposes to GRANTED by default - for all regions except EU",
+        "simpleValueType": true,
+        "help": "Unchecking this option will set all GCM purposes to DENIED across all regions. For more granular control, use the mapping table to set the initial status of GCM purposes by country or territory. Region codes follow the ISO 3166-2 standard for countries and subdivisions."
       }
     ],
     "help": "These fields are denied by default for all regions unless overwritten with a blank region field"
@@ -267,21 +274,6 @@ ___TEMPLATE_PARAMETERS___
         "simpleValueType": true,
         "defaultValue": true,
         "help": "Enable this option if the IAB TCF is enabled for your consent notice in the Didomi Console. See https://support.didomi.io/iab-tcf  for more information.",
-        "enablingConditions": [
-          {
-            "paramName": "embedDidomi",
-            "paramValue": true,
-            "type": "EQUALS"
-          }
-        ]
-      },
-      {
-        "type": "CHECKBOX",
-        "name": "applyGDPRGlobally",
-        "checkboxText": "Apply GDPR globally",
-        "simpleValueType": true,
-        "defaultValue": true,
-        "help": "Enable this option if you want GDPR to apply to all your users. This option must be checked if you are an EU-based company.",
         "enablingConditions": [
           {
             "paramName": "embedDidomi",
@@ -540,72 +532,97 @@ const setupListeners = () => {
   });
 };
 
-const setGrantedConsentValuesForAllRegions = () => {
-  // Set default consent state values to denied for all regions
-  setDefaultConsentState({
-    'ad_storage': 'granted',
-    'analytics_storage': 'granted',
-    'functionality_storage': 'granted',
-    'personalization_storage': 'granted',
-    'security_storage': 'granted',
-    'ad_user_data': 'granted',
-    'ad_personalization': 'granted',
-    'wait_for_update': 500,
+/**
+ * Creates a base consent state configuration object
+ */
+const getBaseConsentState = status => {
+  return {
+    ad_storage: status,
+    analytics_storage: status,
+    functionality_storage: status,
+    personalization_storage: status,
+    security_storage: 'granted',
+    ad_user_data: status,
+    ad_personalization: status,
+    wait_for_update: 500,
+  };
+};
+
+/**
+ * Sets global default consent states based on EU/non-EU configuration
+ */
+const setGlobalDefaults = grantGCMByDefaultOutsideEU => {
+  if (grantGCMByDefaultOutsideEU) {
+    // Set EU regions to denied by default
+    const baseConsentState = getBaseConsentState('denied');
+    const euConsentState = {
+      ad_storage: baseConsentState.ad_storage,
+      analytics_storage: baseConsentState.analytics_storage,
+      functionality_storage: baseConsentState.functionality_storage,
+      personalization_storage: baseConsentState.personalization_storage,
+      security_storage: baseConsentState.security_storage,
+      ad_user_data: baseConsentState.ad_user_data,
+      ad_personalization: baseConsentState.ad_personalization,
+      wait_for_update: baseConsentState.wait_for_update,
+      region: regionsDeniedByDefault,
+    };
+    setDefaultConsentState(euConsentState);
+
+    // Set all other regions to granted by default
+    setDefaultConsentState(getBaseConsentState('granted'));
+  } else {
+    // Set all regions to denied by default
+    setDefaultConsentState(getBaseConsentState('denied'));
+  }
+};
+
+/**
+ * Applies region-specific consent state overrides
+ */
+const applyRegionOverrides = byRegionDefaultStatusTable => {
+  if (!byRegionDefaultStatusTable || byRegionDefaultStatusTable.length === 0) {
+    return;
+  }
+
+  byRegionDefaultStatusTable.forEach(settings => {
+    const statusFromData = {
+      ad_storage: settings[GCM_PURPOSES_MAP.ad_storage],
+      analytics_storage: settings[GCM_PURPOSES_MAP.analytics_storage],
+      functionality_storage: settings[GCM_PURPOSES_MAP.functionality_storage],
+      personalization_storage:
+        settings[GCM_PURPOSES_MAP.personalization_storage],
+      security_storage: 'granted',
+      ad_user_data: settings[GCM_PURPOSES_MAP.ad_user_data],
+      ad_personalization: settings[GCM_PURPOSES_MAP.ad_personalization],
+      wait_for_update: 500,
+    };
+
+    const regions = splitInput(settings.region);
+    if (regions.length > 0) {
+      statusFromData.region = regions;
+    }
+
+    setDefaultConsentState(statusFromData);
   });
 };
 
-const setDefaultSettings = data => {
-  // Set default consent state values for regions denied by default
-  setDefaultConsentState({
-    'region': regionsDeniedByDefault,
-    'ad_storage': 'denied',
-    'analytics_storage': 'denied',
-    'functionality_storage': 'denied',
-    'personalization_storage': 'denied',
-    'security_storage': 'granted',
-    'ad_user_data': 'denied',
-    'ad_personalization': 'denied',
-    'wait_for_update': 500,
-  });
-  // Override the default consent state values for specific regions if set by the client
-  if (
-    data.byRegionDefaultStatusTable &&
-    data.byRegionDefaultStatusTable.length > 0
-  ) {
-    let dataContainsAllRegionsRecord = false;
-    data.byRegionDefaultStatusTable.forEach(settings => {
-      const statusFromData = {
-        'ad_storage': settings[GCM_PURPOSES_MAP.ad_storage],
-        'analytics_storage': settings[GCM_PURPOSES_MAP.analytics_storage],
-        'functionality_storage': settings[GCM_PURPOSES_MAP.functionality_storage],
-        'personalization_storage':
-          settings[GCM_PURPOSES_MAP.personalization_storage],
-        'security_storage': 'granted',
-        'ad_user_data': settings[GCM_PURPOSES_MAP.ad_user_data],
-        'ad_personalization': settings[GCM_PURPOSES_MAP.ad_personalization],
-        'wait_for_update': 500,
-      };
-      const regions = splitInput(settings.region);
-      if (regions.length > 0) {
-        statusFromData.region = regions;
-      } else {
-        dataContainsAllRegionsRecord = true;
-      }
-      // Set default consent state values
-      setDefaultConsentState(statusFromData);
-    });
-    
-    if (!dataContainsAllRegionsRecord) {
-      setGrantedConsentValuesForAllRegions();
-    }
-  } else {
-    setGrantedConsentValuesForAllRegions();
-  }
-  // Set default additional settings values
+/**
+ * Sets additional gtag configuration settings
+ */
+const setAdditionalSettings = (adsDataRedaction, urlPassThrough) => {
   gtagSet({
-    'ads_data_redaction': data.adsDataRedaction,
-    'url_passthrough': data.urlPassThrough,
+    ads_data_redaction: adsDataRedaction,
+    url_passthrough: urlPassThrough,
   });
+};
+
+/**
+ * Main function to set all default settings
+ */
+const setDefaultSettings = data => {
+  setGlobalDefaults(data.grantGCMByDefaultOutsideEU);
+  applyRegionOverrides(data.byRegionDefaultStatusTable);
+  setAdditionalSettings(data.adsDataRedaction, data.urlPassThrough);
 };
 
 // Set developer ID
@@ -623,9 +640,6 @@ if (data.embedDidomi) {
       : encodeUriComponent(data.publicAPIKey) +
         '/loader.js?target=' +
         getUrl('host'));
-
-  // Set window.gdprAppliesGlobally
-  setInWindow('gdprAppliesGlobally', data.applyGDPRGlobally);
 
   if (data.enableTCF) {
     createStub('__tcfapi', '__tcfapiBuffer');
@@ -960,45 +974,6 @@ ___WEB_PERMISSIONS___
           "value": {
             "type": 2,
             "listItem": [
-              {
-                "type": 3,
-                "mapKey": [
-                  {
-                    "type": 1,
-                    "string": "key"
-                  },
-                  {
-                    "type": 1,
-                    "string": "read"
-                  },
-                  {
-                    "type": 1,
-                    "string": "write"
-                  },
-                  {
-                    "type": 1,
-                    "string": "execute"
-                  }
-                ],
-                "mapValue": [
-                  {
-                    "type": 1,
-                    "string": "gdprAppliesGlobally"
-                  },
-                  {
-                    "type": 8,
-                    "boolean": true
-                  },
-                  {
-                    "type": 8,
-                    "boolean": true
-                  },
-                  {
-                    "type": 8,
-                    "boolean": false
-                  }
-                ]
-              },
               {
                 "type": 3,
                 "mapKey": [
@@ -1515,18 +1490,6 @@ scenarios:
     runCode(mockData);
 
     assertApi('setDefaultConsentState').wasCalledWith({
-      'ad_storage': 'granted',
-      'analytics_storage': 'granted',
-      'functionality_storage': 'granted',
-      'personalization_storage': 'granted',
-      'security_storage': 'granted',
-      'ad_user_data': 'granted',
-      'ad_personalization': 'granted',
-      'wait_for_update': 500
-    });
-
-    assertApi('setDefaultConsentState').wasCalledWith({
-      'region': regionsDeniedByDefault,
       'ad_storage': 'denied',
       'analytics_storage': 'denied',
       'functionality_storage': 'denied',
@@ -1560,19 +1523,6 @@ scenarios:
     assertApi('injectScript').wasNotCalled();
     assertApi('gtmOnSuccess').wasCalled();
 
-- name: Template values are set in Windows object
-  code: |-
-    mockData.embedDidomi = true;
-
-    // Call runCode to run the template's code.
-    runCode(mockData);
-
-    const applyGDPRGlobally = copyFromWindow('gdprAppliesGlobally');
-
-    assertThat(applyGDPRGlobally).isEqualTo(mockData.applyGDPRGlobally);
-
-    assertApi('injectScript').wasCalled();
-    assertApi('gtmOnFailure').wasNotCalled();
 - name: SDK is embedded via template (no noticeId)
   code: |+
     const getUrl = require('getUrl');
@@ -1648,18 +1598,6 @@ scenarios:
     didomiOnReady[0]();
 
     assertApi('setDefaultConsentState').wasCalledWith({
-      'ad_storage': 'granted',
-      'analytics_storage': 'granted',
-      'functionality_storage': 'granted',
-      'personalization_storage': 'granted',
-      'security_storage': 'granted',
-      'ad_user_data': 'granted',
-      'ad_personalization': 'granted',
-      'wait_for_update': 500
-    });
-
-    assertApi('setDefaultConsentState').wasCalledWith({
-      'region': regionsDeniedByDefault,
       'ad_storage': 'denied',
       'analytics_storage': 'denied',
       'functionality_storage': 'denied',
@@ -1737,18 +1675,6 @@ scenarios:
     runCode(mockData);
 
     assertApi('setDefaultConsentState').wasCalledWith({
-      'ad_storage': 'granted',
-      'analytics_storage': 'granted',
-      'functionality_storage': 'granted',
-      'personalization_storage': 'granted',
-      'security_storage': 'granted',
-      'ad_user_data': 'granted',
-      'ad_personalization': 'granted',
-      'wait_for_update': 500
-    });
-
-    assertApi('setDefaultConsentState').wasCalledWith({
-      'region': regionsDeniedByDefault,
       'ad_storage': 'denied',
       'analytics_storage': 'denied',
       'functionality_storage': 'denied',
@@ -1825,19 +1751,15 @@ scenarios:
     \ = \"google,googleana-4TXnJigR,\";\ndidomiState.didomiVendorsUnknown = \"\";\n\
     setInWindow('didomiState', didomiState, true);\n\n// Simulate on-ready event trigger\n\
     didomiOnReady[0]();\n\nassertApi('setDefaultConsentState').wasCalledWith({\n \
-    \ 'ad_storage': 'granted',\n  'analytics_storage': 'granted',\n  'functionality_storage':\
-    \ 'granted',\n  'personalization_storage': 'granted',\n  'security_storage': 'granted',\n\
-    \  'ad_user_data': 'granted',\n  'ad_personalization': 'granted',\n  'wait_for_update':\
-    \ 500\n});\n\nassertApi('setDefaultConsentState').wasCalledWith({\n  'region':\
-    \ regionsDeniedByDefault,\n  'ad_storage': 'denied',\n  'analytics_storage': 'denied',\n\
-    \  'functionality_storage': 'denied',\n  'personalization_storage': 'denied',\n\
-    \  'security_storage': 'granted',\n  'ad_user_data': 'denied',\n  'ad_personalization':\
-    \ 'denied',\n  'wait_for_update': 500\n});\n\n/*\nFrom a google's email:\nBecause\
-    \ of the way Tag Manager times the application of consent updates (aligned with\
-    \ event boundaries), the method isConsentGranted will not be an effective way\
-    \ to test for any consent changes that happened during your test. Instead, I would\
-    \ suggest using assertApi().wasCalledWith() to ensure that the setDefaultConsentState\
-    \ and updateConsentState APIs were called with the expected parameters.\n\nassertThat(isConsentGranted('ad_storage')).isEqualTo(true);\n\
+    \ 'ad_storage': 'denied',\n  'analytics_storage': 'denied',\n  'functionality_storage':\
+    \ 'denied',\n  'personalization_storage': 'denied',\n  'security_storage': 'granted',\n\
+    \  'ad_user_data': 'denied',\n  'ad_personalization': 'denied',\n  'wait_for_update':\
+    \ 500\n});\n\n\n/*\nFrom a google's email:\nBecause of the way Tag Manager times\
+    \ the application of consent updates (aligned with event boundaries), the method\
+    \ isConsentGranted will not be an effective way to test for any consent changes\
+    \ that happened during your test. Instead, I would suggest using assertApi().wasCalledWith()\
+    \ to ensure that the setDefaultConsentState and updateConsentState APIs were called\
+    \ with the expected parameters.\n\nassertThat(isConsentGranted('ad_storage')).isEqualTo(true);\n\
     assertThat(isConsentGranted('analytics_storage')).isEqualTo(true);\nassertThat(isConsentGranted('functionality_storage')).isEqualTo(true);\n\
     assertThat(isConsentGranted('personalization_storage')).isEqualTo(true);\n*/ \n\
     \nassertThat(isConsentGranted('security_storage')).isEqualTo(true);\nassertApi('updateConsentState').wasCalledWith({'ad_storage':\
@@ -1926,7 +1848,7 @@ scenarios:
 
 
 - name: Default consent values are correctly overridden for multiple regions (no all
-    regions row included)
+    regions row included and grantGCMByDefaultOutsideEU disabled)
   code: |-
     mockData.byRegionDefaultStatusTable = [{
       "region": "US-CA, US-CO",
@@ -1941,6 +1863,126 @@ scenarios:
 
     // Call runCode to run the template's code.
     runCode(mockData);
+
+
+
+    // Client specific values are used to override default ones
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': ['US-CA','US-CO'],
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'granted',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+
+    // Make sure that setDeniedConsentValuesForAllRegions is called
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'granted',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+
+
+
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Default consent values are correctly overridden for multiple regions (all
+    regions row included and grantGCMByDefaultOutsideEU disabled)
+  code: |-
+    mockData.byRegionDefaultStatusTable = [{
+      "region": "US-CA, US-CO",
+      "adStorage": 'granted',
+      "analyticsStorage": 'granted',
+      "functionalityStorage": 'denied',
+      "personalizationStorage": 'denied',
+      "adUserData": 'denied',
+      "adPersonalization": 'denied'
+    }, {
+      "region": "",
+      "adStorage": 'denied',
+      "analyticsStorage": 'denied',
+      "functionalityStorage": 'granted',
+      "personalizationStorage": 'granted',
+      "adUserData": 'granted',
+      "adPersonalization": 'granted'
+    }];
+
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+
+    // Client specific values are used to override default ones
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': ['US-CA','US-CO'],
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'granted',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+
+    // Make sure that the specific values for all regions are used
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'security_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
+      'wait_for_update': 500
+    });
+
+
+
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Default consent values are correctly overridden for multiple regions (no all
+    regions row included and grantGCMByDefaultOutsideEU enabled)
+  code: |-
+    mockData.grantGCMByDefaultOutsideEU = true;
+
+    mockData.byRegionDefaultStatusTable = [{
+      "region": "US-CA, US-CO",
+      "adStorage": 'granted',
+      "analyticsStorage": 'granted',
+      "functionalityStorage": 'denied',
+      "personalizationStorage": 'denied',
+      "adUserData": 'denied',
+      "adPersonalization": 'denied'
+    }];
+
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsDeniedByDefault,
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'granted',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
 
     assertApi('setDefaultConsentState').wasCalledWith({
       'ad_storage': 'granted',
@@ -1968,7 +2010,19 @@ scenarios:
       'wait_for_update': 500
     });
 
-    // Make sure that setGrantedConsentValuesForAllRegions is called
+
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsDeniedByDefault,
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'granted',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+
     assertApi('setDefaultConsentState').wasCalledWith({
       'ad_storage': 'granted',
       'analytics_storage': 'granted',
@@ -1982,11 +2036,14 @@ scenarios:
 
 
 
+
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
 - name: Default consent values are correctly overridden for multiple regions (all
-    regions row included)
+    regions row included and grantGCMByDefaultOutsideEU enabled)
   code: |-
+    mockData.grantGCMByDefaultOutsideEU = true;
+
     mockData.byRegionDefaultStatusTable = [{
       "region": "US-CA, US-CO",
       "adStorage": 'granted',
@@ -2020,6 +2077,18 @@ scenarios:
       'ad_personalization': 'denied',
       'wait_for_update': 500
     });
+
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'security_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
+      'wait_for_update': 500
+    });
+
 
     // Client specific values are used to override default ones
     assertApi('setDefaultConsentState').wasCalledWith({
@@ -2081,7 +2150,6 @@ setup: |-
     "embedDidomi":false,
     "publicAPIKey":"7685b6f7-3062-491b-ba50-207f440951dc",
     "enableTCF":true,
-    "applyGDPRGlobally":true,
     "noticeId":"BLBwUdiE",
   };
 

--- a/template.tpl
+++ b/template.tpl
@@ -10,9 +10,8 @@ ___INFO___
 
 {
   "type": "TAG",
-  "id": "cvt_temp_public_id",
+  "id": "cvt_MJP6G",
   "version": 1,
-  "securityGroups": [],
   "displayName": "Didomi CMP",
   "categories": [
     "TAG_MANAGEMENT",
@@ -26,7 +25,8 @@ ___INFO___
   "description": "Didomi builds technology to help companies put their users in control of their personal data. By doing so, they generate valuable trust and lay the groundwork for privacy-conscious growth.",
   "containerContexts": [
     "WEB"
-  ]
+  ],
+  "securityGroups": []
 }
 
 
@@ -325,6 +325,69 @@ const copyFromWindow = require('copyFromWindow');
 const createQueue = require('createQueue');
 const Object = require('Object');
 
+const regionsGrantedByDefault = [
+  'US-CA',
+  'US-CO',
+  'US-CT',
+  'US-DE',
+  'US-FL',
+  'US-IA',
+  'US-MT',
+  'US-NH',
+  'US-NJ',
+  'US-OR',
+  'US-TX',
+  'US-UT',
+  'US-VA',
+];
+
+const regionsDeniedByDefault = [
+  'AD',
+  'AT',
+  'BE',
+  'BG',
+  'BR',
+  'CY',
+  'CZ',
+  'DE',
+  'DK',
+  'EE',
+  'ES',
+  'FI',
+  'FR',
+  'GB',
+  'GF',
+  'GG',
+  'GI',
+  'GP',
+  'GR',
+  'HR',
+  'HU',
+  'IE',
+  'IS',
+  'IT',
+  'JE',
+  'LI',
+  'LT',
+  'LU',
+  'LV',
+  'MC',
+  'MF',
+  'MQ',
+  'MT',
+  'NL',
+  'NO',
+  'PL',
+  'PT',
+  'RE',
+  'RO',
+  'SE',
+  'SI',
+  'SK',
+  'SM',
+  'VA',
+  'YT',
+];
 /**
  * Mapping between the consent types and the vendor to use when determining the status of the user for the consent type
  */
@@ -338,12 +401,12 @@ const consentTypesVendorMap = {
 };
 
 const gcmVendorId = {
-  ad_storage: 'didomi:google',
-  analytics_storage: 'c:googleana-4TXnJigR',
-  functionality_storage: 'didomi:google',
-  personalization_storage: 'didomi:google',
-  ad_user_data: 'didomi:google',
-  ad_personalization: 'didomi:google'
+  ad_storage: 'google',
+  analytics_storage: 'googleana-4TXnJigR',
+  functionality_storage: 'google',
+  personalization_storage: 'google',
+  ad_user_data: 'google',
+  ad_personalization: 'google',
 };
 
 const PURPOSES_STATUSES = {
@@ -357,20 +420,21 @@ const GCM_PURPOSES_MAP = {
   functionality_storage: 'functionalityStorage',
   personalization_storage: 'personalizationStorage',
   ad_user_data: 'adUserData',
-  ad_personalization: 'adPersonalization'
+  ad_personalization: 'adPersonalization',
 };
 
-const splitInput = (input) => {
-  return input.split(',')
+const splitInput = input => {
+  return input
+    .split(',')
     .map(entry => entry.trim())
     .filter(entry => entry.length !== 0);
 };
 
 /**
-* Returns GCM purpose status (`granted` or `denied`)
-* based on the boolean consent status value
-*/
-const getGCMPurposeStatus = (consentStatus) => {
+ * Returns GCM purpose status (`granted` or `denied`)
+ * based on the boolean consent status value
+ */
+const getGCMPurposeStatus = consentStatus => {
   return consentStatus === true ? PURPOSES_STATUSES.granted : PURPOSES_STATUSES.denied;
 };
 
@@ -414,7 +478,11 @@ const createStub = (fnName, bufferName) => {
  * @param {*} consentType
  */
 const isDidomiConsentUnknown = (didomiState, consentType) => {
- return didomiState && didomiState.didomiVendorsConsentUnknown.indexOf(gcmVendorId[consentType] + ",") !== -1;
+  return (
+    didomiState &&
+    didomiState.didomiVendorsUnknown.indexOf(gcmVendorId[consentType] + ',') !==
+      -1
+  );
 };
 
 /**
@@ -424,25 +492,42 @@ const isDidomiConsentUnknown = (didomiState, consentType) => {
  * @param {*} consentType
  */
 const isDidomiConsentGranted = (didomiState, consentType) => {
- return didomiState && didomiState.didomiVendorsConsent.indexOf(gcmVendorId[consentType] + ",") !== -1;
+  return (
+    didomiState &&
+    didomiState.didomiVendorsEnabled.indexOf(gcmVendorId[consentType] + ',') !==
+      -1
+  );
 };
 
 const gcmEnabledFromSDK = () => {
   const didomiConfig = callInWindow('Didomi.getConfig');
-     return didomiConfig && didomiConfig.integrations && didomiConfig.integrations.vendors && didomiConfig.integrations.vendors.gcm && didomiConfig.integrations.vendors.gcm.enable === true;
+  return (
+    didomiConfig &&
+    didomiConfig.integrations &&
+    didomiConfig.integrations.vendors &&
+    didomiConfig.integrations.vendors.gcm &&
+    didomiConfig.integrations.vendors.gcm.enable === true
+  );
 };
 
-const updateGCMState = (eventData) => {
+const updateGCMState = eventData => {
   if (gcmEnabledFromSDK()) return;
   const didomiState = copyFromWindow('didomiState');
-  if (eventData === 'ready' && isDidomiConsentUnknown(didomiState, 'ad_storage') && isDidomiConsentUnknown(didomiState, 'analytics_storage')) return;
+  if (
+    eventData === 'ready' &&
+    isDidomiConsentUnknown(didomiState, 'ad_storage') &&
+    isDidomiConsentUnknown(didomiState, 'analytics_storage')
+  )
+    return;
 
   const statusFromDidomiState = {};
 
   const consentTypes = Object.keys(GCM_PURPOSES_MAP);
 
   consentTypes.forEach(consentType => {
-    if (!isDidomiConsentUnknown(didomiState, consentTypesVendorMap[consentType])) {
+    if (
+      !isDidomiConsentUnknown(didomiState, consentTypesVendorMap[consentType])
+    ) {
       statusFromDidomiState[consentType] = getGCMPurposeStatus(
         isDidomiConsentGranted(didomiState, consentType)
       );
@@ -457,18 +542,18 @@ const updateGCMState = (eventData) => {
  *
  */
 const setupListeners = () => {
-    const didomiEventListenersPush = createQueue('didomiEventListeners');
+  const didomiEventListenersPush = createQueue('didomiEventListeners');
 
-    didomiEventListenersPush({
-      event: 'consent.changed',
-      listener: () => updateGCMState('consent-changed'),
-   });
+  didomiEventListenersPush({
+    event: 'consent.changed',
+    listener: () => updateGCMState('consent-changed'),
+  });
 
-   const didomiOnReadyPush = createQueue('didomiOnReady');
-    didomiOnReadyPush(function () {
-      // Initialization code
-      updateGCMState('ready');
-    });
+  const didomiOnReadyPush = createQueue('didomiOnReady');
+  didomiOnReadyPush(function () {
+    // Initialization code
+    updateGCMState('ready');
+  });
 };
 
 const setDeniedConsentValuesForAllRegions = () => {
@@ -485,16 +570,44 @@ const setDeniedConsentValuesForAllRegions = () => {
   });
 };
 
-const setDefaultSettings = (data) => {
-  // Set default consent state values for specific regions is set by the client
-  if (data.byRegionDefaultStatusTable && data.byRegionDefaultStatusTable.length > 0) {
+const setDefaultSettings = data => {
+  // Set default consent state values for regions granted by default
+  setDefaultConsentState({
+    'region': regionsGrantedByDefault,
+    'ad_storage': 'granted',
+    'analytics_storage': 'granted',
+    'functionality_storage': 'granted',
+    'personalization_storage': 'granted',
+    'security_storage': 'granted',
+    'ad_user_data': 'granted',
+    'ad_personalization': 'granted',
+    'wait_for_update': 500,
+  });
+  // Set default consent state values for regions denied by default
+  setDefaultConsentState({
+    'region': regionsDeniedByDefault,
+    'ad_storage': 'denied',
+    'analytics_storage': 'denied',
+    'functionality_storage': 'denied',
+    'personalization_storage': 'denied',
+    'security_storage': 'denied',
+    'ad_user_data': 'denied',
+    'ad_personalization': 'denied',
+    'wait_for_update': 500,
+  });
+  // Override the default consent state values for specific regions if set by the client
+  if (
+    data.byRegionDefaultStatusTable &&
+    data.byRegionDefaultStatusTable.length > 0
+  ) {
     let dataContainsAllRegionsRecord = false;
     data.byRegionDefaultStatusTable.forEach(settings => {
       const statusFromData = {
         'ad_storage': settings[GCM_PURPOSES_MAP.ad_storage],
         'analytics_storage': settings[GCM_PURPOSES_MAP.analytics_storage],
         'functionality_storage': settings[GCM_PURPOSES_MAP.functionality_storage],
-        'personalization_storage': settings[GCM_PURPOSES_MAP.personalization_storage],
+        'personalization_storage':
+          settings[GCM_PURPOSES_MAP.personalization_storage],
         'security_storage': 'granted',
         'ad_user_data': settings[GCM_PURPOSES_MAP.ad_user_data],
         'ad_personalization': settings[GCM_PURPOSES_MAP.ad_personalization],
@@ -518,10 +631,9 @@ const setDefaultSettings = (data) => {
   }
   // Set default additional settings values
   gtagSet({
-  'ads_data_redaction': data.adsDataRedaction,
-  'url_passthrough': data.urlPassThrough,
+    'ads_data_redaction': data.adsDataRedaction,
+    'url_passthrough': data.urlPassThrough,
   });
-
 };
 
 // Set developer ID
@@ -531,16 +643,20 @@ gtagSet('developer_id.dMTc4Zm', true);
 setDefaultSettings(data);
 
 if (data.embedDidomi) {
-    let scriptUrl = 'https://sdk.privacy-center.org/' + (data.noticeId ?  encodeUriComponent(data.publicAPIKey) + '/loader.js?target_type=notice&target=' + encodeUriComponent(data.noticeId) : encodeUriComponent(data.publicAPIKey) + '/loader.js?target=' + getUrl("host"));
+  let scriptUrl =
+    'https://sdk.privacy-center.org/' +
+    (data.noticeId ? encodeUriComponent(data.publicAPIKey) +
+        '/loader.js?target_type=notice&target=' +
+        encodeUriComponent(data.noticeId)
+      : encodeUriComponent(data.publicAPIKey) +
+        '/loader.js?target=' +
+        getUrl('host'));
 
   // Set window.gdprAppliesGlobally
   setInWindow('gdprAppliesGlobally', data.applyGDPRGlobally);
 
   if (data.enableTCF) {
-    createStub(
-    '__tcfapi',
-    '__tcfapiBuffer'
-    );
+    createStub('__tcfapi', '__tcfapiBuffer');
   }
 
   // This the logic found in src/tag/loaders/*.ejs (web sdk repo)
@@ -1648,8 +1764,8 @@ scenarios:
     const didomiEventListeners = copyFromWindow('didomiEventListeners');
     // simulate changes coming from the SDK
     // user gives consent to both google and google analytics vendors and purposes
-    didomiState.didomiVendorsConsent = "didomi:google,c:googleana-4TXnJigR,";
-    didomiState.didomiVendorsConsentUnknown = "";
+    didomiState.didomiVendorsEnabled = "google,googleana-4TXnJigR,";
+    didomiState.didomiVendorsUnknown = "";
     setInWindow('didomiState', didomiState, true);
 
     // Simulate on-changed event trigger
@@ -1673,18 +1789,21 @@ scenarios:
     const didomiOnReady = copyFromWindow('didomiOnReady');
     // simulate changes coming from the SDK
     // user has given consent to both google and google analytics vendors and purposes
-    didomiState.didomiVendorsConsent = "didomi:google,c:googleana-4TXnJigR,";
-    didomiState.didomiVendorsConsentUnknown = "";
+    didomiState.didomiVendorsEnabled = "google,googleana-4TXnJigR,";
+    didomiState.didomiVendorsUnknown = "";
     setInWindow('didomiState', didomiState, true);
 
     // Simulate on-ready event trigger
     didomiOnReady[0]();
 
-    assertThat(isConsentGranted('ad_storage')).isEqualTo(true);
-    assertThat(isConsentGranted('analytics_storage')).isEqualTo(true);
-    assertThat(isConsentGranted('functionality_storage')).isEqualTo(true);
-    assertThat(isConsentGranted('personalization_storage')).isEqualTo(true);
-    assertThat(isConsentGranted('security_storage')).isEqualTo(true);
+    assertApi('updateConsentState').wasCalledWith({
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted'
+    });
 
 
     // Verify that the tag finished successfully.
@@ -1693,11 +1812,11 @@ scenarios:
     the current page
   code: "// Call runCode to run the template's code.\nrunCode(mockData);\n\nconst\
     \ didomiOnReady = copyFromWindow('didomiOnReady');\n// simulate changes coming\
-    \ from the SDK\n// user has given consent to both ad and analytics storage\ndidomiState.didomiVendorsConsent\
-    \ = \"didomi:google,c:googleana-4TXnJigR,\";\ndidomiState.didomiVendorsConsentUnknown\
-    \ = \"\";\nsetInWindow('didomiState', didomiState, true);\n\n// Simulate on-ready\
-    \ event trigger\ndidomiOnReady[0]();\n\nassertApi('setDefaultConsentState').wasCalledWith({\n\
-    \  'ad_storage': 'denied',\n  'analytics_storage': 'denied',\n  'functionality_storage':\
+    \ from the SDK\n// user has given consent to both ad and analytics storage\ndidomiState.didomiVendorsEnabled\
+    \ = \"google,googleana-4TXnJigR,\";\ndidomiState.didomiVendorsUnknown = \"\";\n\
+    setInWindow('didomiState', didomiState, true);\n\n// Simulate on-ready event trigger\n\
+    didomiOnReady[0]();\n\nassertApi('setDefaultConsentState').wasCalledWith({\n \
+    \ 'ad_storage': 'denied',\n  'analytics_storage': 'denied',\n  'functionality_storage':\
     \ 'denied',\n  'personalization_storage': 'denied',\n  'security_storage': 'granted',\n\
     \  'ad_user_data': 'denied',\n  'ad_personalization': 'denied',\n  'wait_for_update':\
     \ 500\n});\n/*\nFrom a google's email:\nBecause of the way Tag Manager times the\
@@ -1713,8 +1832,8 @@ scenarios:
     \ 'granted',\n  'personalization_storage': 'granted',\n  'ad_user_data': 'granted',\n\
     \  'ad_personalization': 'granted'});\n\nconst didomiEventListeners = copyFromWindow('didomiEventListeners');\n\
     // simulate changes coming from the SDK\n// user changes consent for both ad and\
-    \ analytics storage\ndidomiState.didomiVendorsConsentDenied = \"didomi:google,c:googleana-4TXnJigR,\"\
-    ;\ndidomiState.didomiVendorsConsent = \"\";\ndidomiState.didomiVendorsConsentUnknown\
+    \ analytics storage\ndidomiState.didomiVendorsDisabled = \"google,googleana-4TXnJigR,\"\
+    ;\ndidomiState.didomiVendorsEnabled = \"\";\ndidomiState.didomiVendorsUnknown\
     \ = \"\";\nsetInWindow('didomiState', didomiState, true);\n\n// Simulate on-changed\
     \ event trigger\ndidomiEventListeners[0].listener();\n\n\nassertApi('updateConsentState').wasCalledWith({'ad_storage':\
     \ 'denied',\n  'analytics_storage': 'denied',\n    'functionality_storage': 'denied',\n\
@@ -1736,8 +1855,8 @@ scenarios:
     \  'ad_user_data': 'denied',\n  'ad_personalization': 'denied',\n  'wait_for_update':\
     \ 500\n});\n\nconst didomiOnReady = copyFromWindow('didomiOnReady');\n\n// simulate\
     \ changes coming from the SDK\n// user has given consent to google \n// google\
-    \ analytics is still in unknown state\ndidomiState.didomiVendorsConsent = \"didomi:google,\"\
-    ;\ndidomiState.didomiVendorsConsentUnknown = \"c:googleana-4TXnJigR,\";\nsetInWindow('didomiState',\
+    \ analytics is still in unknown state\ndidomiState.didomiVendorsEnabled = \"google,\"\
+    ;\ndidomiState.didomiVendorsUnknown = \"googleana-4TXnJigR,\";\nsetInWindow('didomiState',\
     \ didomiState, true);\n\n// Simulate on-ready event trigger\ndidomiOnReady[0]();\n\
     \n\n/*\nFrom a google's email:\nBecause of the way Tag Manager times the application\
     \ of consent updates (aligned with event boundaries), the method isConsentGranted\
@@ -1764,8 +1883,8 @@ scenarios:
     \ 'denied',\n  'ad_personalization': 'denied',\n  'wait_for_update': 500});\n\n\
     const didomiOnReady = copyFromWindow('didomiOnReady');\n\n// simulate changes\
     \ coming from the SDK\n// user has given consent to google analytics \n// google\
-    \ (storage) is still in unknown state\ndidomiState.didomiVendorsConsent = \"c:googleana-4TXnJigR,\"\
-    ;\ndidomiState.didomiVendorsConsentUnknown = \"didomi:google,\";\nsetInWindow('didomiState',\
+    \ (storage) is still in unknown state\ndidomiState.didomiVendorsEnabled = \"googleana-4TXnJigR,\"\
+    ;\ndidomiState.didomiVendorsUnknown = \"google,\";\nsetInWindow('didomiState',\
     \ didomiState, true);\n\n// Simulate on-ready event trigger\ndidomiOnReady[0]();\n\
     \nassertThat(isConsentGranted('security_storage')).isEqualTo(true);\nassertApi('updateConsentState').wasCalledWith({\n\
     \  'analytics_storage': 'granted',\n});\n\n\n/*\nFrom a google's email:\nBecause\
@@ -1793,8 +1912,8 @@ scenarios:
 
 
 
-- name: Default consent values are set correctly for multiple regions (no all regions
-    row included)
+- name: Default consent values are correctly overridden for multiple regions (no all
+    regions row included)
   code: |-
     mockData.byRegionDefaultStatusTable = [{
       "region": "US-CA, US-CO",
@@ -1810,7 +1929,33 @@ scenarios:
     // Call runCode to run the template's code.
     runCode(mockData);
 
+    // setDefaultConsentState is called with Didomi's default values per regiont
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsGrantedByDefault,
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'security_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
+      'wait_for_update': 500
+    });
 
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsDeniedByDefault,
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+
+
+    // Client specific values are used to override default ones
     assertApi('setDefaultConsentState').wasCalledWith({
       'region': ['US-CA','US-CO'],
       'ad_storage': 'granted',
@@ -1864,7 +2009,32 @@ scenarios:
     // Call runCode to run the template's code.
     runCode(mockData);
 
+    // setDefaultConsentState is called with Didomi's default values per regiont
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsGrantedByDefault,
+      'ad_storage': 'granted',
+      'analytics_storage': 'granted',
+      'functionality_storage': 'granted',
+      'personalization_storage': 'granted',
+      'security_storage': 'granted',
+      'ad_user_data': 'granted',
+      'ad_personalization': 'granted',
+      'wait_for_update': 500
+    });
 
+    assertApi('setDefaultConsentState').wasCalledWith({
+      'region': regionsDeniedByDefault,
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'functionality_storage': 'denied',
+      'personalization_storage': 'denied',
+      'security_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+
+    // Client specific values are used to override default ones
     assertApi('setDefaultConsentState').wasCalledWith({
       'region': ['US-CA','US-CO'],
       'ad_storage': 'granted',
@@ -1942,7 +2112,74 @@ setup: |-
     "didomiVendorsRawConsent": "",
     "didomiVendorsRawConsentDenied": "",
   "didomiVendorsRawConsentUnknown": "didomi:google,c:googleana-4TXnJigR,",
+    "didomiVendorsEnabled": "",
+    "didomiVendorsDisabled": "",
+    "didomiVendorsUnknown": "google,googleana-4TXnJigR,",
   };
+
+  const regionsGrantedByDefault = [
+    'US-CA',
+    'US-CO',
+    'US-CT',
+    'US-DE',
+    'US-FL',
+    'US-IA',
+    'US-MT',
+    'US-NH',
+    'US-NJ',
+    'US-OR',
+    'US-TX',
+    'US-UT',
+    'US-VA',
+  ];
+
+  const regionsDeniedByDefault = [
+    'AD',
+    'AT',
+    'BE',
+    'BG',
+    'BR',
+    'CY',
+    'CZ',
+    'DE',
+    'DK',
+    'EE',
+    'ES',
+    'FI',
+    'FR',
+    'GB',
+    'GF',
+    'GG',
+    'GI',
+    'GP',
+    'GR',
+    'HR',
+    'HU',
+    'IE',
+    'IS',
+    'IT',
+    'JE',
+    'LI',
+    'LT',
+    'LU',
+    'LV',
+    'MC',
+    'MF',
+    'MQ',
+    'MT',
+    'NL',
+    'NO',
+    'PL',
+    'PT',
+    'RE',
+    'RO',
+    'SE',
+    'SI',
+    'SK',
+    'SM',
+    'VA',
+    'YT',
+  ];
 
 
 ___NOTES___


### PR DESCRIPTION
## Add Regional Default Consent Settings and Update GCM Vendor IDs for Non-GDPR Regulations

### Overview
This MR introduces predefined regional consent defaults to streamline Google Consent Mode configuration and updates GCM vendor IDs to support non-GDPR regulations.

### Key Changes

#### **Regional Default Arrays**
- **`regionsDeniedByDefault`**: Pre-configured array of GDPR regions (EU countries, UK, Brazil, etc.) that default to denied consent
- **Default behavior**: A new `grantGCMByDefaultOutsideEU` control variable was introduced as a checkbox. When enabled all regions **except** GDPR ones are now set to **granted** consent by default.
<img width="907" height="475" alt="Screenshot 2025-08-13 at 14 53 13" src="https://github.com/user-attachments/assets/6cb6971b-fc0c-45f2-957a-c299ea1bcfe0" />


#### ⚡ **Direct Integration with setDefaultConsentState**
- The `regionsDeniedByDefault` array is directly passed to `setDefaultConsentState()` calls
- **No configuration delays**: Eliminates the need to extract regional logic from config objects at runtime
- **Immediate application**: Regional defaults are applied instantly during template initialization

#### 🎯 **Alignment with Didomi's Regulation Logic**
- Regional groupings match Didomi's internal regulation mapping
- **"None" regulation equivalent**: Non-GDPR regions default to granted consent, mirroring backend behavior
- Ensures consistency between Didomi CMP behavior and Google Consent Mode defaults
- Maintains regulatory compliance across different jurisdictions

#### 🔧 **User Override Capability**
- Users can override default regional settings through the parameter table
- **Flexible configuration**: Add specific regions with custom consent values
- **Fallback support**: If no user overrides are provided, defaults are applied
- **All-regions override**: Users can set global defaults by leaving the region field blank

#### 🆔 **Updated GCM Vendor IDs**
- **Enhanced `gcmVendorId` mapping**: Updated to support non-GDPR regulations
- **Regulation-agnostic mapping**: Vendor IDs now work across different regulations

#### 🎛️ **New Global Configuration Option**
- `grantGCMByDefaultOutsideEU`: New checkbox parameter that controls the default consent behavior
- When enabled: GDPR regions are denied by default, all other regions are granted by default
- When disabled: All regions are denied by default (legacy behavior)
 -Backward compatibility: Maintains existing behavior for users who don't enable the new option

####🗑️ **Removed Deprecated Parameter**
- `applyGDPRGlobally`: Removed this parameter as it's been deprecated in the Web SDK for a while.

### Technical Implementation
```javascript
// Direct array usage in setDefaultConsentState calls
setDefaultConsentState({
  'region': regionsDeniedByDefault,
  'ad_storage': 'denied',
  // ... other consent types
});

// All other regions default to granted (equivalent to "none" regulation)
setDefaultConsentState({
  'ad_storage': 'granted',
  // ... other consent types
});
```

### Benefits
- **Performance improvement**: No runtime configuration parsing required
- **Consistency**: Aligns with Didomi's regulatory logic and backend "none" regulation parameter
- **Flexibility**: Maintains user override capabilities
- **Maintainability**: Centralized regional definitions for easy updates
- **Regulatory coverage**: Enhanced support for non-GDPR privacy regulations
- **Simplified logic**: Clear distinction between GDPR (denied) and non-GDPR (granted) regions



